### PR TITLE
Only display the plugin's settings errors, not all

### DIFF
--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -46,6 +46,19 @@ class WP_Widget_Disable {
 	protected $dashboard_widgets_option = 'rplus_wp_widget_disable_dashboard_option';
 
 	/**
+	 * Saves empty values for the plugin's options upon plugin activation.
+	 *
+	 * @link https://core.trac.wordpress.org/ticket/21989
+	 * @link https://github.com/wearerequired/WP-Widget-Disable/issues/11
+	 *
+	 * @since 1.6.1
+	 */
+	public function set_default_options() {
+		add_option( $this->sidebar_widgets_option, array() );
+		add_option( $this->dashboard_widgets_option, array() );
+	}
+
+	/**
 	 * Adds hooks.
 	 */
 	public function add_hooks() {

--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -60,7 +60,7 @@ class WP_Widget_Disable {
 	 * @link https://core.trac.wordpress.org/ticket/21989
 	 * @link https://github.com/wearerequired/WP-Widget-Disable/issues/11
 	 *
-	 * @since 1.6.1
+	 * @since 1.7.0
 	 */
 	public function set_default_options() {
 		if ( false === get_option( $this->sidebar_widgets_option, false ) ) {

--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -63,8 +63,13 @@ class WP_Widget_Disable {
 	 * @since 1.6.1
 	 */
 	public function set_default_options() {
-		add_option( $this->sidebar_widgets_option, array() );
-		add_option( $this->dashboard_widgets_option, array() );
+		if ( false === get_option( $this->sidebar_widgets_option, false ) ) {
+			add_option( $this->sidebar_widgets_option, array() );
+		}
+
+		if ( false === get_option( $this->dashboard_widgets_option, false ) ) {
+			add_option( $this->dashboard_widgets_option, array() );
+		}
 	}
 
 	/**

--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -56,7 +56,7 @@ class WP_Widget_Disable {
 		add_action( 'admin_init', array( $this, 'register_settings' ) );
 
 		// Display settings errors.
-		add_action( 'admin_notices', 'settings_errors' );
+		add_action( 'admin_notices', array( $this, 'settings_errors' ) );
 
 		// Get and disable the sidebar widgets.
 		add_action( 'widgets_init', array( $this, 'set_default_sidebar_widgets' ), 100 );
@@ -121,6 +121,15 @@ class WP_Widget_Disable {
 	 */
 	public function settings_page_callback() {
 		include( trailingslashit( $this->get_path() ) . 'views/admin.php' );
+	}
+
+	/**
+	 * Displays the settings errors on the plugin's settings page.
+	 *
+	 * @since 1.7.0
+	 */
+	public function settings_errors() {
+		settings_errors( 'wp-widget-disable' );
 	}
 
 	/**

--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -308,7 +308,11 @@ class WP_Widget_Disable {
 		// Create our array for storing the validated options.
 		$output = array();
 		if ( empty( $input ) ) {
-			$message = __( 'All sidebar widgets are enabled again.', 'wp-widget-disable' );
+			if ( empty( get_option( $this->sidebar_widgets_option, array() ) ) ) {
+				$message = __( 'Settings saved.', 'wp-widget-disable' );
+			} else {
+				$message = __( 'All sidebar widgets are enabled again.', 'wp-widget-disable' );
+			}
 		} else {
 			// Loop through each of the incoming options.
 			foreach ( array_keys( $input ) as $key ) {
@@ -357,7 +361,11 @@ class WP_Widget_Disable {
 		// Create our array for storing the validated options.
 		$output = array();
 		if ( empty( $input ) ) {
-			$message = __( 'All dashboard widgets are enabled again.', 'wp-widget-disable' );
+			if ( empty( get_option( $this->dashboard_widgets_option, array() ) ) ) {
+				$message = __( 'Settings saved.', 'wp-widget-disable' );
+			} else {
+				$message = __( 'All dashboard widgets are enabled again.', 'wp-widget-disable' );
+			}
 		} else {
 			// Loop through each of the incoming options.
 			foreach ( array_keys( $input ) as $key ) {

--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -269,7 +269,7 @@ class WP_Widget_Disable {
 	 * @since 1.0.0
 	 */
 	public function disable_dashboard_widgets() {
-		$widgets = (array) get_option( $this->dashboard_widgets_option );
+		$widgets = (array) get_option( $this->dashboard_widgets_option, array() );
 		if ( ! $widgets ) {
 			return;
 		}
@@ -453,7 +453,7 @@ class WP_Widget_Disable {
 			return;
 		}
 
-		$options = (array) get_option( $this->sidebar_widgets_option );
+		$options = (array) get_option( $this->sidebar_widgets_option, array() );
 		?>
 		<p>
 			<input type="checkbox" id="wp_widget_disable_select_all"/>
@@ -492,7 +492,7 @@ class WP_Widget_Disable {
 			return;
 		}
 
-		$options = (array) get_option( $this->dashboard_widgets_option );
+		$options = (array) get_option( $this->dashboard_widgets_option, array() );
 		?>
 		<p>
 			<input type="checkbox" id="wp_widget_disable_select_all"/>

--- a/wp-widget-disable.php
+++ b/wp-widget-disable.php
@@ -46,6 +46,8 @@ if ( $requirements_check->passes() ) {
 
 	$wp_widget_disable = new WP_Widget_Disable();
 	add_action( 'plugins_loaded', array( $wp_widget_disable, 'add_hooks' ) );
+
+	register_activation_hook( __FILE__, array( $wp_widget_disable, 'set_default_options' ) );
 }
 
 unset( $requirements_check );


### PR DESCRIPTION
Fixes #11.

The settings might be duplicated because another plugin of ours interferes with it and is calling just `settings_errors()` as well.