### PR TITLE
Begin with network admin compatibility

### DIFF
--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -84,7 +84,7 @@ class WP_Widget_Disable {
 
 		// Multisite compatibility
 		add_action( 'network_admin_menu', array( $this, 'admin_menu' ) );
-		add_action(	'network_admin_edit_wp-widget-disable', array( $this, 'save_network_options' ) );
+		add_action( 'network_admin_edit_wp-widget-disable', array( $this, 'save_network_options' ) );
 
 		// Display settings errors.
 		add_action( 'admin_notices', array( $this, 'settings_errors' ) );

--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -55,24 +55,6 @@ class WP_Widget_Disable {
 	protected $page_hook = '';
 
 	/**
-	 * Saves empty values for the plugin's options upon plugin activation.
-	 *
-	 * @link https://core.trac.wordpress.org/ticket/21989
-	 * @link https://github.com/wearerequired/WP-Widget-Disable/issues/11
-	 *
-	 * @since 1.7.0
-	 */
-	public function set_default_options() {
-		if ( false === get_option( $this->sidebar_widgets_option, false ) ) {
-			add_option( $this->sidebar_widgets_option, array() );
-		}
-
-		if ( false === get_option( $this->dashboard_widgets_option, false ) ) {
-			add_option( $this->dashboard_widgets_option, array() );
-		}
-	}
-
-	/**
 	 * Adds hooks.
 	 */
 	public function add_hooks() {

--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -83,8 +83,6 @@ class WP_Widget_Disable {
 		// Add an action link pointing to the setting page.
 		add_action( 'plugin_action_links_' . $this->get_basename(), array( $this, 'plugin_action_links' ) );
 
-		add_action( 'admin_footer_text', array( $this, 'admin_footer_text' ) );
-
 		add_action( 'admin_print_styles', array( $this, 'print_admin_styles' ) );
 	}
 
@@ -247,26 +245,6 @@ class WP_Widget_Disable {
 			),
 			$links
 		);
-	}
-
-	/**
-	 * Add admin footer text to plugins page.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param  string $text Default admin footer text.
-	 *
-	 * @return string
-	 */
-	public function admin_footer_text( $text ) {
-		$screen = get_current_screen();
-
-		if ( $screen && $this->page_hook === $screen->base ) {
-			/* translators: %s: required */
-			$text = sprintf( __( 'WP Widget Disable is brought to you by %s. We &hearts; WordPress.', 'wp-widget-disable' ), '<a href="https://required.com">required</a>' );
-		}
-
-		return $text;
 	}
 
 	/**

--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -88,6 +88,7 @@ class WP_Widget_Disable {
 
 		// Display settings errors.
 		add_action( 'admin_notices', array( $this, 'settings_errors' ) );
+		add_action( 'network_admin_notices', array( $this, 'settings_errors' ) );
 
 		// Get and disable the sidebar widgets.
 		add_action( 'widgets_init', array( $this, 'set_default_sidebar_widgets' ), 100 );

--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -458,7 +458,7 @@ class WP_Widget_Disable {
 		if ( $message ) {
 			add_settings_error(
 				'wp-widget-disable',
-				esc_attr( 'settings_updated' ),
+				'settings_updated',
 				$message,
 				'updated'
 			);
@@ -512,7 +512,7 @@ class WP_Widget_Disable {
 		if ( $message ) {
 			add_settings_error(
 				'wp-widget-disable',
-				esc_attr( 'settings_updated' ),
+				'settings_updated',
 				$message,
 				'updated'
 			);

--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -405,16 +405,11 @@ class WP_Widget_Disable {
 	 * @return array
 	 */
 	public function sanitize_sidebar_widgets( $input ) {
-		// Create our array for storing the validated options.
-		$output = array();
+		$output  = array();
+		$message = null;
+
 		if ( empty( $input ) ) {
-			$option = get_option( $this->sidebar_widgets_option, array() );
-
 			$message = __( 'All sidebar widgets are enabled again.', 'wp-widget-disable' );
-
-			if ( empty( $option ) ) {
-				$message = __( 'Settings saved.', 'wp-widget-disable' );
-			}
 		} else {
 			// Loop through each of the incoming options.
 			foreach ( array_keys( $input ) as $key ) {
@@ -441,12 +436,14 @@ class WP_Widget_Disable {
 			}
 		}
 
-		add_settings_error(
-			'wp-widget-disable',
-			esc_attr( 'settings_updated' ),
-			$message,
-			'updated'
-		);
+		if ( $message ) {
+			add_settings_error(
+				'wp-widget-disable',
+				esc_attr( 'settings_updated' ),
+				$message,
+				'updated'
+			);
+		}
 
 		return $output;
 	}
@@ -462,19 +459,11 @@ class WP_Widget_Disable {
 	 */
 	public function sanitize_dashboard_widgets( $input ) {
 		// Create our array for storing the validated options.
-		$output = array();
+		$output  = array();
+		$message = null;
+
 		if ( empty( $input ) ) {
-			$option = get_option( $this->dashboard_widgets_option, array() );
-
-			if ( is_network_admin() ) {
-				$option = get_site_option( $this->dashboard_widgets_option, array() );
-			}
-
 			$message = __( 'All dashboard widgets are enabled again.', 'wp-widget-disable' );
-
-			if ( empty( $option ) ) {
-				$message = __( 'Settings saved.', 'wp-widget-disable' );
-			}
 		} else {
 			// Loop through each of the incoming options.
 			foreach ( array_keys( $input ) as $key ) {
@@ -501,12 +490,14 @@ class WP_Widget_Disable {
 			}
 		}
 
-		add_settings_error(
-			'wp-widget-disable',
-			esc_attr( 'settings_updated' ),
-			$message,
-			'updated'
-		);
+		if ( $message ) {
+			add_settings_error(
+				'wp-widget-disable',
+				esc_attr( 'settings_updated' ),
+				$message,
+				'updated'
+			);
+		}
 
 		return $output;
 	}

--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -191,6 +191,17 @@ class WP_Widget_Disable {
 	}
 
 	/**
+	 * Whether there are settings errors for the plugin's settings page.
+	 *
+	 * @since 1.9.0
+	 *
+	 * @return bool True if settings errors exist, false if not.
+	 */
+	public function has_settings_errors() {
+		return count( get_settings_errors( 'wp-widget-disable' ) ) > 0;
+	}
+
+	/**
 	 * Saves network options in the network admin.
 	 *
 	 * Handles settings errors and redirects back to options page.
@@ -211,7 +222,7 @@ class WP_Widget_Disable {
 		update_site_option( $this->dashboard_widgets_option, $data );
 
 		// If no settings errors were registered add a general 'updated' message.
-		if ( ! count( get_settings_errors() ) ) {
+		if ( ! $this->has_settings_errors() ) {
 			add_settings_error( 'wp-widget-disable', 'settings_updated', __( 'Settings saved.', 'wp-widget-disable' ), 'updated' );
 		}
 
@@ -425,6 +436,13 @@ class WP_Widget_Disable {
 	 * @return array
 	 */
 	public function sanitize_sidebar_widgets( $input ) {
+		// If there are settings errors the input was already sanitized.
+		// See https://core.trac.wordpress.org/ticket/21989.
+		if ( $this->has_settings_errors() ) {
+			return $input;
+		}
+
+		// Create our array for storing the validated options.
 		$output  = array();
 		$message = null;
 
@@ -479,6 +497,12 @@ class WP_Widget_Disable {
 	 * @return array
 	 */
 	public function sanitize_dashboard_widgets( $input ) {
+		// If there are settings errors the input was already sanitized.
+		// See https://core.trac.wordpress.org/ticket/21989.
+		if ( $this->has_settings_errors() ) {
+			return $input;
+		}
+
 		// Create our array for storing the validated options.
 		$output  = array();
 		$message = null;

--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -192,10 +192,14 @@ class WP_Widget_Disable {
 	/**
 	 * Saves network options in the network admin.
 	 *
+	 * Handles settings errors and redirects back to options page.
+	 *
+	 * For single sites, this is handled by wp-admin/options.php.
+	 *
 	 * @since 1.9.0
 	 */
 	public function save_network_options() {
-		$data = '';
+		$data = array();
 
 		if ( isset( $_POST[ $this->dashboard_widgets_option ] ) ) {
 			$data = $this->sanitize_dashboard_widgets( $_POST[ $this->dashboard_widgets_option ] );
@@ -203,9 +207,19 @@ class WP_Widget_Disable {
 
 		update_site_option( $this->dashboard_widgets_option, $data );
 
+		// If no settings errors were registered add a general 'updated' message.
+		if ( ! count( get_settings_errors() ) ) {
+			add_settings_error( 'general', 'settings_updated', __( 'Settings saved.', 'wp-widget-disable' ), 'updated' );
+		}
+
+		set_transient( 'settings_errors', get_settings_errors(), 30 );
+
 		wp_safe_redirect(
 			add_query_arg(
-				array( 'page' => 'wp-widget-disable' ),
+				array(
+					'page' => 'wp-widget-disable',
+					'settings-updated' => 1,
+				),
 				network_admin_url( 'settings.php' )
 			)
 		);

--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -82,8 +82,6 @@ class WP_Widget_Disable {
 
 		// Add an action link pointing to the setting page.
 		add_action( 'plugin_action_links_' . $this->get_basename(), array( $this, 'plugin_action_links' ) );
-
-		add_action( 'admin_print_styles', array( $this, 'print_admin_styles' ) );
 	}
 
 	/**
@@ -245,31 +243,6 @@ class WP_Widget_Disable {
 			),
 			$links
 		);
-	}
-
-	/**
-	 * Prints additional styles used for the settings form.
-	 *
-	 * @since 1.6.1
-	 */
-	public function print_admin_styles() {
-		$screen = get_current_screen();
-
-		if ( ! $screen || $this->page_hook !== $screen->base ) {
-			return;
-		}
-
-		?>
-		<style>
-		.wp-widget-disable-form .button-link {
-			color: #0073aa;
-		}
-		.wp-widget-disable-form .button-link:hover,
-		.wp-widget-disable-form .button-link:focus {
-			color: #00a0d2;
-		}
-		</style>
-		<?php
 	}
 
 	/**

--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -126,7 +126,7 @@ class WP_Widget_Disable {
 	/**
 	 * Returns the plugin basename.
 	 *
-	 * @since 1.8.0
+	 * @since 1.9.0
 	 *
 	 * @return string The plugin basename.
 	 */
@@ -192,7 +192,7 @@ class WP_Widget_Disable {
 	/**
 	 * Saves network options in the network admin.
 	 *
-	 * @since 1.8.0
+	 * @since 1.9.0
 	 */
 	public function save_network_options() {
 		$data = '';

--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -211,7 +211,7 @@ class WP_Widget_Disable {
 
 		// If no settings errors were registered add a general 'updated' message.
 		if ( ! count( get_settings_errors() ) ) {
-			add_settings_error( 'general', 'settings_updated', __( 'Settings saved.', 'wp-widget-disable' ), 'updated' );
+			add_settings_error( 'wp-widget-disable', 'settings_updated', __( 'Settings saved.', 'wp-widget-disable' ), 'updated' );
 		}
 
 		set_transient( 'settings_errors', get_settings_errors(), 30 );

--- a/classes/class-wp-widget-disable.php
+++ b/classes/class-wp-widget-disable.php
@@ -440,7 +440,8 @@ class WP_Widget_Disable {
 				}
 			}
 
-			if ( 1 === count( $output ) ) {
+			$output_count = count( $output );
+			if ( 1 === $output_count ) {
 				$message = __( 'Settings saved. One sidebar widget disabled.', 'wp-widget-disable' );
 			} else {
 				$message = sprintf(
@@ -448,10 +449,10 @@ class WP_Widget_Disable {
 					_n(
 						'Settings saved. %d sidebar widget disabled.',
 						'Settings saved. %d sidebar widgets disabled.',
-						count( $output ),
+						number_format_i18n( $output_count ),
 						'wp-widget-disable'
 					),
-					count( $output )
+					$output_count
 				);
 			}
 		}
@@ -494,7 +495,8 @@ class WP_Widget_Disable {
 				}
 			}
 
-			if ( 1 === count( $output ) ) {
+			$output_count = count( $output );
+			if ( 1 === $output_count ) {
 				$message = __( 'Settings saved. One dashboard widget disabled.', 'wp-widget-disable' );
 			} else {
 				$message = sprintf(
@@ -502,10 +504,10 @@ class WP_Widget_Disable {
 					_n(
 						'Settings saved. %d dashboard widget disabled.',
 						'Settings saved. %d dashboard widgets disabled.',
-						count( $output ),
+						number_format_i18n( $output_count ),
 						'wp-widget-disable'
 					),
-					count( $output )
+					$output_count
 				);
 			}
 		}

--- a/views/admin.php
+++ b/views/admin.php
@@ -25,6 +25,10 @@
 
 	$form_action = is_network_admin() ? network_admin_url( 'edit.php?action=wp-widget-disable' ) : admin_url( 'options.php' );
 
+	if ( is_network_admin() ) {
+		settings_errors();
+	}
+
 	if ( ! is_network_admin() ) :
 	?>
 

--- a/views/admin.php
+++ b/views/admin.php
@@ -19,9 +19,13 @@
 	<?php
 	$active_tab = $this->sidebar_widgets_option;
 
-	if ( isset( $_GET['tab'] ) && 'dashboard' === $_GET['tab'] ) {
+	if ( ( isset( $_GET['tab'] ) && 'dashboard' === $_GET['tab'] ) || is_network_admin() ) {
 		$active_tab = $this->dashboard_widgets_option;
 	}
+
+	$form_action = is_network_admin() ? network_admin_url( 'edit.php?action=wp-widget-disable' ) : admin_url( 'options.php' );
+
+	if ( ! is_network_admin() ) :
 	?>
 
 	<h2 class="nav-tab-wrapper">
@@ -34,6 +38,7 @@
 			'tab'  => 'dashboard'
 		) ) ); ?>" class="nav-tab <?php echo $this->dashboard_widgets_option === $active_tab ? 'nav-tab-active' : ''; ?>"><?php _e( 'Dashboard Widgets', 'wp-widget-disable' ); ?></a>
 	</h2>
+	<?php endif; ?>
 
 	<script type="text/javascript">
 		jQuery( document ).ready( function( $ ) {
@@ -46,7 +51,7 @@
 		} );
 	</script>
 
-	<form method="post" action="options.php" class="wp-widget-disable-form">
+	<form method="post" action="<?php echo esc_url( $form_action ); ?>" class="wp-widget-disable-form">
 		<?php
 		settings_fields( $active_tab );
 		do_settings_sections( $active_tab );

--- a/views/admin.php
+++ b/views/admin.php
@@ -29,7 +29,7 @@ $dashboard_tab_url = add_query_arg(
 $active_tab = $this->sidebar_widgets_option;
 
 // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
-if ( isset( $_GET['tab'] ) && 'dashboard' === $_GET['tab'] ) {
+if ( is_network_admin() || ( isset( $_GET['tab'] ) && 'dashboard' === $_GET['tab'] ) ) {
 	$active_tab = $this->dashboard_widgets_option;
 }
 

--- a/views/admin.php
+++ b/views/admin.php
@@ -39,12 +39,7 @@ $form_action = is_network_admin() ? network_admin_url( 'edit.php?action=wp-widge
 <div class="wrap">
 	<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 
-
 	<?php
-	if ( is_network_admin() ) {
-		settings_errors();
-	}
-
 	if ( ! is_network_admin() ) :
 		?>
 	<h2 class="nav-tab-wrapper">

--- a/wp-widget-disable.php
+++ b/wp-widget-disable.php
@@ -47,8 +47,6 @@ if ( $requirements_check->passes() ) {
 
 	$wp_widget_disable = new WP_Widget_Disable();
 	add_action( 'plugins_loaded', array( $wp_widget_disable, 'add_hooks' ) );
-
-	register_activation_hook( __FILE__, array( $wp_widget_disable, 'set_default_options' ) );
 }
 
 unset( $requirements_check );


### PR DESCRIPTION
With this patch, the network admin looks like this:

<img width="844" alt="screen shot 2018-05-02 at 20 26 04" src="https://user-images.githubusercontent.com/841956/39541829-2918be58-4e47-11e8-9e63-12cbc9feecd4.png">


To do:

* [x] Show message after saving settings.  
`add_settings_error()` doesn't work because there's a redirect happening. We could add a GET parameter in that case, .e.g. `&updated=<count>`.

Fixes #29.